### PR TITLE
Update README warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ happily accept them.
 
 **Warning:** I assume you know what you're doing.
 
-**Warning 2:** Tested on macOS, some users have reported that [`xxd` on Linux behaves differently](https://github.com/phretor/intel-leak-checker/issues/1#issuecomment-1274705257).
+**Warning 2**: The script was tested mainly on MacOS, in order for the script to work on Linux, make sure to have **`xxd` version 2022-01-14 (coming with [vim 8.2.4088](https://github.com/vim/vim/commit/c0a1d370fa655cea9eaa74f5e605b95825dc9de1)) or newer**, [see more details why here.](https://unix.stackexchange.com/a/706374/287583)
 
 ## Standalone Usage
 


### PR DESCRIPTION
- Add the required `xxd` version for a more consistent detection behavior on Linux.
- Workaround for #1 

I was also thinking of a way to not run the script if the version reported of `xxd` is lower than 2022-01-14, but I'm not too sure if it's a good idea, it would be adding a few lines, matching the date reported in the version of `xxd`, and then compares this integer, if it's equal or higher than this, then `xxd`'s version should be all good for them.
```bash
echo $(date -d $(xxd --version 2> >(sed -nE "s/.*([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p")) +%s)
1642114800
```

Maybe, there is also the need to check if we're on macOS or not, in order to need such a requirement only on Linux.

But I feel just this snippet, is going too far into bash, for protecting users from misusing the checker script, if they read the README, they won't make the mistake, but if you think, it could be nice to have, I can open a second PR for that, feel free to let me know @phretor

Thanks a lot for this project, by the way !